### PR TITLE
Enabled CORS and fixed choices OpenAPI documentation.

### DIFF
--- a/Evostory/EvoStory.BackendAPI/Controllers/ChoiceController.cs
+++ b/Evostory/EvoStory.BackendAPI/Controllers/ChoiceController.cs
@@ -3,11 +3,13 @@ using EvoStory.BackendAPI.DTO;
 using Evostory.Story.Models;
 using System.Net.Mime;
 using EvoStory.BackendAPI.Services;
+using Microsoft.AspNetCore.Cors;
 
 namespace EvoStory.BackendAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [EnableCors("allowedOrigins")]
     public class ChoiceController(IChoiceService choiceService) : ControllerBase
     {
         /// <summary>
@@ -62,7 +64,7 @@ namespace EvoStory.BackendAPI.Controllers
         /// <response code="200">The Choices were succesfully retrieved.</response>
         [HttpGet(Name = nameof(GetChoices))]
         [Produces(MediaTypeNames.Application.Json)]
-        [ProducesResponseType(typeof(IEnumerable<CreateChoiceDTO>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IEnumerable<ChoiceDTO>), StatusCodes.Status200OK)]
         public ActionResult GetChoices()
         {
             IEnumerable<ChoiceDTO> result;

--- a/Evostory/EvoStory.BackendAPI/Controllers/SceneController.cs
+++ b/Evostory/EvoStory.BackendAPI/Controllers/SceneController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoStory.BackendAPI.DTO;
 using EvoStory.BackendAPI.Services;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Mime;
 
@@ -7,6 +8,8 @@ namespace EvoStory.BackendAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+
+    [EnableCors("allowedOrigins")]
     public class SceneController(ISceneService sceneService) : ControllerBase
     {
         /// <summary>

--- a/Evostory/EvoStory.BackendAPI/Controllers/StoryController.cs
+++ b/Evostory/EvoStory.BackendAPI/Controllers/StoryController.cs
@@ -1,5 +1,6 @@
 ﻿using EvoStory.BackendAPI.DTO;
 using EvoStory.BackendAPI.Services;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;
 using System.Net.Mime;
 
@@ -7,6 +8,7 @@ namespace EvoStory.BackendAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [EnableCors("allowedOrigins")]
     public class StoryController(IStoryService storyService) : ControllerBase
     {
         /// <summary>

--- a/Evostory/EvoStory.BackendAPI/Program.cs
+++ b/Evostory/EvoStory.BackendAPI/Program.cs
@@ -26,7 +26,20 @@ builder.Services.AddSingleton<IDTOConversionService, DTOConversionService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var allowedSpecificOrigins = "allowedOrigins";
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy(name: allowedSpecificOrigins,
+                      policy =>
+                      {
+                          policy.WithOrigins("http://localhost:5173")
+                            .AllowAnyHeader()
+                            .AllowAnyMethod();
+                      });
+});
+
 var app = builder.Build();
+app.UseCors(allowedSpecificOrigins);
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())


### PR DESCRIPTION
CORS is enabled for the default frontend server (vite). OpenAPI documentation fixed for GetAllChoices endpoint.